### PR TITLE
Patch 2

### DIFF
--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute062.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute062.cfg
@@ -128,7 +128,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True

--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute125.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute125.cfg
@@ -127,7 +127,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True

--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute1875.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute1875.cfg
@@ -130,7 +130,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True

--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute250.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute250.cfg
@@ -125,7 +125,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True

--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute375.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute375.cfg
@@ -129,7 +129,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True

--- a/GameData/KermangeddonIndustries/InlineBallutes/Ballute500.cfg
+++ b/GameData/KermangeddonIndustries/InlineBallutes/Ballute500.cfg
@@ -127,7 +127,7 @@ PART
 		dragCubeName = DEPLOYED
 		dragModifier = 0.6
 	}
-	MODULE
+	MODULE:NEEDS[DeadlyReentry]
 	{
 		name = ModuleAeroReentry
 		leaveTemp = True


### PR DESCRIPTION
The only other place I can find ModuleAeroReentry is in the DeadlyReentry mod.   This should stop the parts from throwing errors when loading a stock game. 